### PR TITLE
workaround for broken builds in node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "precommit": "tslint -p . --fix; git-clang-format --extensions ts",
     "clean": "rm -rf node_modules/ Gulpfile.js *.spec.js"
   },
+  "__COMMENTS__": [
+    "natives@1.1.6 for Gulp 3.x on Node 10.x: https://github.com/gulpjs/gulp/issues/2162#issuecomment-385197164"
+  ],
   "devDependencies": {
     "@types/base-64": "^0.1.2",
     "@types/gulp": "^4.0.4",
@@ -32,5 +35,8 @@
   "dependencies": {
     "base-64": "^0.1.0",
     "punycode": "^1.4.1"
+  },
+  "resolutions": {
+    "natives": "1.1.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1292,9 +1292,10 @@ mute-stdout@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mute-stdout/-/mute-stdout-1.0.0.tgz#5b32ea07eb43c9ded6130434cf926f46b2a7fd4d"
 
-natives@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31"
+natives@1.1.6, natives@^1.1.0:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 next-tick@1:
   version "1.0.0"


### PR DESCRIPTION
Same as:
https://github.com/Jigsaw-Code/outline-client/pull/434

To simplify:
https://github.com/Jigsaw-Code/outline-shadowsocksconfig/pull/7