### PR TITLE
Use ES6 imports; migrate to js-base64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
 
 before_install:
   # https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Travis-CI-supports-yarn
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.5
   - export PATH="$HOME/.yarn/bin:$PATH"
 
 script:

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,0 @@
-{
-  "name": "shadowsocks-config",
-  "version": "0.0.8",
-  "license": "Apache-2.0",
-  "main": "shadowsocks_config.js",
-  "dependencies": {
-    "punycode": "^1.4.1"
-  }
-}

--- a/build/shadowsocks_config.js
+++ b/build/shadowsocks_config.js
@@ -23,16 +23,8 @@ var __extends = (this && this.__extends) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
-/* tslint:disable */
-var isBrowser = typeof window !== 'undefined';
-var b64Encode = isBrowser ? btoa : require('base-64').encode;
-var b64Decode = isBrowser ? atob : require('base-64').decode;
-var URL = isBrowser ? window.URL : require('url').URL;
-var punycode = isBrowser ? window.punycode : require('punycode');
-if (!punycode) {
-    throw new Error("Could not find punycode. Did you forget to add e.g.\n  <script src=\"bower_components/punycode/punycode.min.js\"></script>?");
-}
-/* tslint:enable */
+var punycode = require('punycode');
+var js_base64_1 = require('js-base64');
 // Custom error base class
 var ShadowsocksConfigError = /** @class */ (function (_super) {
     __extends(ShadowsocksConfigError, _super);
@@ -252,7 +244,7 @@ exports.LEGACY_BASE64_URI = {
         var tagStartIndex = hasTag ? hashIndex + 1 : uri.length;
         var tag = new Tag(decodeURIComponent(uri.substring(tagStartIndex)));
         var b64EncodedData = uri.substring('ss://'.length, b64EndIndex);
-        var b64DecodedData = b64Decode(b64EncodedData);
+        var b64DecodedData = js_base64_1.Base64.decode(b64EncodedData);
         var atSignIndex = b64DecodedData.lastIndexOf('@');
         if (atSignIndex === -1) {
             throw new InvalidUri("Missing \"@\"");
@@ -292,7 +284,8 @@ exports.LEGACY_BASE64_URI = {
     stringify: function (config) {
         var host = config.host, port = config.port, method = config.method, password = config.password, tag = config.tag;
         var hash = exports.SHADOWSOCKS_URI.getHash(tag);
-        var b64EncodedData = b64Encode(method.data + ":" + password.data + "@" + host.data + ":" + port.data);
+        var b64EncodedData = js_base64_1.Base64.encode(
+            method.data + ':' + password.data + '@' + host.data + ':' + port.data);
         var dataLength = b64EncodedData.length;
         var paddingLength = 0;
         for (; b64EncodedData[dataLength - 1 - paddingLength] === '='; paddingLength++)
@@ -321,13 +314,13 @@ exports.SIP002_URI = {
         if (!parsedPort && uri.match(/:80($|\/)/g)) {
             // The default URL parser fails to recognize the default port (80) when the URI being parsed
             // is HTTP. Check if the port is present at the end of the string or before the parameters.
-            parsedPort = 80;
+            parsedPort = '80';
         }
         var port = new Port(parsedPort);
         var tag = new Tag(decodeURIComponent(urlParserResult.hash.substring(1)));
         var b64EncodedUserInfo = urlParserResult.username.replace(/%3D/g, '=');
         // base64.decode throws as desired when given invalid base64 input.
-        var b64DecodedUserInfo = b64Decode(b64EncodedUserInfo);
+        var b64DecodedUserInfo = js_base64_1.Base64.decode(b64EncodedUserInfo);
         var colonIdx = b64DecodedUserInfo.indexOf(':');
         if (colonIdx === -1) {
             throw new InvalidUri("Missing password");
@@ -349,7 +342,7 @@ exports.SIP002_URI = {
     },
     stringify: function (config) {
         var host = config.host, port = config.port, method = config.method, password = config.password, tag = config.tag, extra = config.extra;
-        var userInfo = b64Encode(method.data + ":" + password.data);
+        var userInfo = js_base64_1.Base64.encode(method.data + ':' + password.data);
         var uriHost = exports.SHADOWSOCKS_URI.getUriFormattedHost(host);
         var hash = exports.SHADOWSOCKS_URI.getHash(tag);
         var queryString = '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outline-shadowsocksconfig",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsc",
@@ -10,7 +10,6 @@
   "main": "./build/shadowsocks_config.js",
   "types": "./build/shadowsocks_config.d.ts",
   "devDependencies": {
-    "@types/base-64": "^0.1.2",
     "@types/jasmine": "^2.8.6",
     "@types/node": "^8.0.41",
     "clang-format": "^1.2.2",
@@ -20,7 +19,7 @@
     "typescript": "^2.5.3"
   },
   "dependencies": {
-    "base-64": "^0.1.0",
+    "js-base64": "^3.5.2",
     "punycode": "^1.4.1"
   },
   "husky": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,6 @@
 # yarn lockfile v1
 
 
-"@types/base-64@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@types/base-64/-/base-64-0.1.2.tgz#63ac318302cdabb5f04e8ae2a56e54d4832107e2"
-
 "@types/jasmine@^2.8.6":
   version "2.8.6"
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.6.tgz#14445b6a1613cf4e05dd61c3c3256d0e95c0421e"
@@ -52,10 +48,6 @@ babel-code-frame@^6.22.0:
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-
-base-64@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -343,6 +335,11 @@ jasmine@^3.1.0:
   dependencies:
     glob "^7.0.6"
     jasmine-core "~3.1.0"
+
+js-base64@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.5.2.tgz#3cc800e4f10812b55fb5ec53e7cabaef35dc6d3c"
+  integrity sha512-VG2qfvV5rEQIVxq9UmAVyWIaOdZGt9M16BLu8vFkyWyhv709Hyg4nKUb5T+Ru+HmAr9RHdF+kQDKAhbJlcdKeQ==
 
 js-tokens@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
- Removes import logic for detecting browser and node environments by using ES6 imports.
  - Drops support for browser imports; users must browserify node_modules dependencies.
- Migrates from `base-64` to `js-base64`, which is actively maintained.
- Removes deprecated bower.json
- Fixes the version string in package.json (current release is v0.0.9).
- Updates yarn to the latest version on CI.