### PR TITLE
bump version number in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outline-shadowsocksconfig",
-  "version": "0.0.9",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Bump the version number in package.json. Bumping to 0.1.2 so I can cut a new release after 0.1.1.