### PR TITLE
switch legacy ss urls to use base64 encoding instead of base64url

### DIFF
--- a/build/shadowsocks_config.js
+++ b/build/shadowsocks_config.js
@@ -285,7 +285,11 @@ exports.LEGACY_BASE64_URI = {
         var host = config.host, port = config.port, method = config.method, password = config.password, tag = config.tag;
         var hash = exports.SHADOWSOCKS_URI.getHash(tag);
         var data = method.data + ":" + password.data + "@" + host.data + ":" + port.data;
-        var b64EncodedData = js_base64_1.Base64.encodeURI(data);
+        var b64EncodedData = js_base64_1.Base64.encode(data);
+        // Remove "=" padding
+        while (b64EncodedData.slice(-1) == "=") {
+            b64EncodedData = b64EncodedData.slice(0, -1);
+        }
         return "ss://" + b64EncodedData + hash;
     },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outline-shadowsocksconfig",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsc",

--- a/src/shadowsocks_config.spec.ts
+++ b/src/shadowsocks_config.spec.ts
@@ -244,7 +244,7 @@ describe('shadowsocks_config', () => {
         tag: 'Foo Bar',
       });
       expect(LEGACY_BASE64_URI.stringify(config)).toEqual(
-        'ss://YmYtY2ZiOuWwj-a0nuS4jeihpeWkp-a0nuWQg-iLpkAxOTIuMTY4LjEwMC4xOjg4ODg#Foo%20Bar');
+        'ss://YmYtY2ZiOuWwj+a0nuS4jeihpeWkp+a0nuWQg+iLpkAxOTIuMTY4LjEwMC4xOjg4ODg#Foo%20Bar');
     });
   });
 
@@ -363,7 +363,7 @@ describe('shadowsocks_config', () => {
     });
 
     it('can parse a valid legacy base64 URI with a non-latin password', () => {
-      const input = 'ss://YmYtY2ZiOuWwj-a0nuS4jeihpeWkp-a0nuWQg-iLpkAxOTIuMTY4LjEwMC4xOjg4ODg#Foo%20Bar';
+      const input = 'ss://YmYtY2ZiOuWwj+a0nuS4jeihpeWkp+a0nuWQg+iLpkAxOTIuMTY4LjEwMC4xOjg4ODg#Foo%20Bar';
       const config = SHADOWSOCKS_URI.parse(input);
       expect(config.method.data).toEqual('bf-cfb');
       expect(config.password.data).toEqual('小洞不补大洞吃苦');

--- a/src/shadowsocks_config.ts
+++ b/src/shadowsocks_config.ts
@@ -265,7 +265,11 @@ export const LEGACY_BASE64_URI = {
     const {host, port, method, password, tag} = config;
     const hash = SHADOWSOCKS_URI.getHash(tag);
     const data = `${method.data}:${password.data}@${host.data}:${port.data}`;
-    const b64EncodedData = Base64.encodeURI(data);
+    let b64EncodedData = Base64.encode(data);
+    // Remove "=" padding
+    while (b64EncodedData.slice(-1) == "=") {
+      b64EncodedData = b64EncodedData.slice(0, -1)
+    }
     return `ss://${b64EncodedData}${hash}`;
   },
 };


### PR DESCRIPTION
https://github.com/Jigsaw-Code/outline-server/issues/774

The non-latin legacy password test also tests that the padding is removed.

I'd like to address getting rid of the .js files in a separate pull request.