### PR TITLE
Add support for unexpanded IPv6 addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Some fields are validated, normalized, and/or sanitized, but not all:
 
 - `host`
   - May be an IPv4, IPv6, or hostname.
-  - IPv6 `::` shorthand is not currently supported.
   - Unicode hostnames are converted to punycode.
   - Hostnames must begin with a character in the set `[A-z0-9]`.
 - `port`

--- a/build/shadowsocks_config.d.ts
+++ b/build/shadowsocks_config.d.ts
@@ -8,8 +8,6 @@ export declare class InvalidUri extends ShadowsocksConfigError {
 export declare abstract class ValidatedConfigField {
 }
 export declare class Host extends ValidatedConfigField {
-    static IPV4_PATTERN: RegExp;
-    static IPV6_PATTERN: RegExp;
     static HOSTNAME_PATTERN: RegExp;
     readonly data: string;
     readonly isIPv4: boolean;

--- a/build/shadowsocks_config.js
+++ b/build/shadowsocks_config.js
@@ -85,7 +85,7 @@ var Host = /** @class */ (function (_super) {
             _this.isIPv6 = ip.kind() == "ipv6";
             // Previous versions of outline-ShadowsocksConfig only accept
             // IPv6 in normalized (expanded) form, so we normalize the
-            // input here.
+            // input here to ensure that access keys remain compatible.
             host = ip.toNormalizedString();
         }
         else {

--- a/build/shadowsocks_config.js
+++ b/build/shadowsocks_config.js
@@ -24,6 +24,7 @@ var __extends = (this && this.__extends) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
 var js_base64_1 = require("js-base64");
+var ipaddr = require("ipaddr.js");
 var punycode = require("punycode");
 // Custom error base class
 var ShadowsocksConfigError = /** @class */ (function (_super) {
@@ -69,24 +70,34 @@ var Host = /** @class */ (function (_super) {
     __extends(Host, _super);
     function Host(host) {
         var _this = _super.call(this) || this;
+        _this.isIPv4 = false;
+        _this.isIPv6 = false;
+        _this.isHostname = false;
         if (!host) {
             throwErrorForInvalidField('host', host);
         }
         if (host instanceof Host) {
             host = host.data;
         }
-        host = punycode.toASCII(host);
-        _this.isIPv4 = Host.IPV4_PATTERN.test(host);
-        _this.isIPv6 = _this.isIPv4 ? false : Host.IPV6_PATTERN.test(host);
-        _this.isHostname = _this.isIPv4 || _this.isIPv6 ? false : Host.HOSTNAME_PATTERN.test(host);
-        if (!(_this.isIPv4 || _this.isIPv6 || _this.isHostname)) {
-            throwErrorForInvalidField('host', host);
+        if (ipaddr.isValid(host)) {
+            var ip = ipaddr.parse(host);
+            _this.isIPv4 = ip.kind() == "ipv4";
+            _this.isIPv6 = ip.kind() == "ipv6";
+            // Previous versions of outline-ShadowsocksConfig only accept
+            // IPv6 in normalized (expanded) form, so we normalize the
+            // input here.
+            host = ip.toNormalizedString();
+        }
+        else {
+            host = punycode.toASCII(host);
+            _this.isHostname = Host.HOSTNAME_PATTERN.test(host);
+            if (!_this.isHostname) {
+                throwErrorForInvalidField('host', host);
+            }
         }
         _this.data = host;
         return _this;
     }
-    Host.IPV4_PATTERN = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/;
-    Host.IPV6_PATTERN = /^(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}$/i;
     Host.HOSTNAME_PATTERN = /^[A-z0-9]+[A-z0-9_.-]*$/;
     return Host;
 }(ValidatedConfigField));

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typescript": "^2.5.3"
   },
   "dependencies": {
+    "ipaddr.js": "^2.0.0",
     "js-base64": "^3.5.2",
     "punycode": "^1.4.1"
   },

--- a/src/shadowsocks_config.spec.ts
+++ b/src/shadowsocks_config.spec.ts
@@ -301,6 +301,15 @@ describe('shadowsocks_config', () => {
       expect(config.port.data).toEqual(8888);
     });
 
+    it('can parse a valid SIP002 URI with a compressed IPv6 host', () => {
+      const input = 'ss://YWVzLTEyOC1nY206dGVzdA@[2001::fffe]:8888';
+      const config = SHADOWSOCKS_URI.parse(input);
+      expect(config.method.data).toEqual('aes-128-gcm');
+      expect(config.password.data).toEqual('test');
+      expect(config.host.data).toEqual('2001:0:0:0:0:0:0:fffe');
+      expect(config.port.data).toEqual(8888);
+    });
+
     it('can parse a valid SIP002 URI with a non-latin password', () => {
       const input = 'ss://YWVzLTEyOC1nY2065bCP5rSe5LiN6KGl5aSn5rSe5ZCD6Ium@192.168.100.1:8888';
       const config = SHADOWSOCKS_URI.parse(input);

--- a/src/shadowsocks_config.spec.ts
+++ b/src/shadowsocks_config.spec.ts
@@ -49,11 +49,29 @@ describe('shadowsocks_config', () => {
       }
     });
 
-    it('accepts IPv6 address hosts', () => {
-      // IPv6 '::' shorthand is unsupported, so '::1' would fail here.
+    it('preserves normalized IPv6 address hosts', () => {
       for (const valid of ['0:0:0:0:0:0:0:1', '2001:0:ce49:7601:e866:efff:62c3:fffe']) {
         const host = new Host(valid);
         expect(host.data).toEqual(valid);
+        expect(host.isIPv4).toBeFalsy();
+        expect(host.isIPv6).toBeTruthy();
+        expect(host.isHostname).toBeFalsy();
+      }
+    });
+
+    it('normalizes IPv6 address hosts', () => {
+      const testCases = [
+        // Canonical form
+        ['::1', '0:0:0:0:0:0:0:1'],
+        ['2001:db8::', '2001:db8:0:0:0:0:0:0'],
+        // Expanded form
+        ['1:02:003:0004:005:06:7:08', '1:2:3:4:5:6:7:8'],
+        // IPv4-mapped form
+        ['::ffff:192.0.2.128', '0:0:0:0:0:ffff:c000:280']
+      ]
+      for (const [input, expanded] of testCases) {
+        const host = new Host(input);
+        expect(host.data).toEqual(expanded);
         expect(host.isIPv4).toBeFalsy();
         expect(host.isIPv6).toBeTruthy();
         expect(host.isHostname).toBeFalsy();

--- a/yarn.lock
+++ b/yarn.lock
@@ -298,6 +298,11 @@ inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
+ipaddr.js@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.0.0.tgz#77ccccc8063ae71ab65c55f21b090698e763fc6e"
+  integrity sha512-S54H9mIj0rbxRIyrDMEuuER86LdlgUg9FSeZ8duQb6CUG2iRrA36MYVQBSprTF/ZeAwvyQ5mDGuNvIPM0BIl3w==
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"


### PR DESCRIPTION
This should make it easier to create and use IPv6 servers.

Fixes #17