### PR TITLE
Online config URL parsing

### DIFF
--- a/build/shadowsocks_config.d.ts
+++ b/build/shadowsocks_config.d.ts
@@ -64,7 +64,7 @@ export declare const SIP002_URI: {
     stringify: (config: Config) => string;
 };
 export interface DynamicConfig {
-  accessUrl: URL;
+  url: string;
   extra: {[key: string]: string;};
 }
 export declare const SIP008_URI: {

--- a/build/shadowsocks_config.d.ts
+++ b/build/shadowsocks_config.d.ts
@@ -61,10 +61,10 @@ export declare const SIP002_URI: {
     parse: (uri: string) => Config;
     stringify: (config: Config) => string;
 };
-export interface OnlineConfig {
+export interface ConfigFetchParams {
   readonly url: string;
-  readonly extra: {[key: string]: string;};
+  readonly certFingerprint?: string;
+  readonly httpMethod?: string;
 }
-export declare const SIP008_URI: {
-  PROTOCOL: string; validateProtocol: (uri: string) => void; parse: (uri: string) => OnlineConfig;
-};
+export declare const ONLINE_CONFIG_PROTOCOL = 'ssconf';
+export declare function parseOnlineConfigUrl(url: string): ConfigFetchParams;

--- a/build/shadowsocks_config.d.ts
+++ b/build/shadowsocks_config.d.ts
@@ -62,7 +62,7 @@ export declare const SIP002_URI: {
     stringify: (config: Config) => string;
 };
 export interface ConfigFetchParams {
-  readonly url: string;
+  readonly location: string;
   readonly certFingerprint?: string;
   readonly httpMethod?: string;
 }

--- a/build/shadowsocks_config.d.ts
+++ b/build/shadowsocks_config.d.ts
@@ -61,14 +61,10 @@ export declare const SIP002_URI: {
     parse: (uri: string) => Config;
     stringify: (config: Config) => string;
 };
-export interface DynamicConfig {
-    url: string;
-    extra: {
-        [key: string]: string;
-    };
+export interface OnlineConfig {
+  readonly url: string;
+  readonly extra: {[key: string]: string;};
 }
 export declare const SIP008_URI: {
-    PROTOCOL: string;
-    validateProtocol: (uri: string) => void;
-    parse: (uri: string) => DynamicConfig;
+  PROTOCOL: string; validateProtocol: (uri: string) => void; parse: (uri: string) => OnlineConfig;
 };

--- a/build/shadowsocks_config.d.ts
+++ b/build/shadowsocks_config.d.ts
@@ -63,3 +63,10 @@ export declare const SIP002_URI: {
     parse: (uri: string) => Config;
     stringify: (config: Config) => string;
 };
+export interface DynamicConfig {
+  accessUrl: URL;
+  extra: {[key: string]: string;};
+}
+export declare const SIP008_URI: {
+  PROTOCOL: string; validateProtocol: (uri: string) => void; parse: (uri: string) => DynamicConfig;
+};

--- a/build/shadowsocks_config.js
+++ b/build/shadowsocks_config.js
@@ -396,8 +396,7 @@ exports.SIP008_URI = {
     var config = {
       // Build the access URL with the parsed parameters. Exclude the query string, as the spec
       // recommends against it.
-      accessUrl:
-          new URL('https://' + uriFormattedHost + ':' + port.data + urlParserResult.pathname),
+      url: 'https://' + uriFormattedHost + ':' + port.data + urlParserResult.pathname,
       extra: extra
     };
     return config;

--- a/build/shadowsocks_config.js
+++ b/build/shadowsocks_config.js
@@ -375,19 +375,18 @@ exports.SIP008_URI = {
         exports.SIP008_URI.validateProtocol(uri);
         // URL parser for expedience, replacing the protocol "ssconf" with "https" to ensure correct
         // results, otherwise browsers like Safari fail to parse it.
-        var inputForUrlParser = "https" + decodeURIComponent(uri.substring(exports.SIP008_URI.PROTOCOL.length));
+        var inputForUrlParser = uri.replace(new RegExp('^' + exports.SIP008_URI.PROTOCOL), 'https');
         // The built-in URL parser throws as desired when given URIs with invalid syntax.
         var urlParserResult = new URL(inputForUrlParser);
         // Use ValidatedConfigFields subclasses (Host, Port, Tag) to throw on validation failure.
         var uriFormattedHost = urlParserResult.hostname;
         var host;
         try {
-            host = new Host(uriFormattedHost);
-        }
-        catch (_) {
-            // Could be IPv6 host formatted with surrounding brackets, so try stripping first and last
-            // characters. If this throws, give up and let the exception propagate.
-            host = new Host(uriFormattedHost.substring(1, uriFormattedHost.length - 1));
+          host = new Host(uriFormattedHost);
+        } catch (_) {
+          // Could be IPv6 host formatted with surrounding brackets, so try stripping first and last
+          // characters. If this throws, give up and let the exception propagate.
+          host = new Host(uriFormattedHost.substring(1, uriFormattedHost.length - 1));
         }
         // The default URL parser fails to recognize the default HTTPs port (443).
         var port = new Port(urlParserResult.port || '443');

--- a/build/shadowsocks_config.js
+++ b/build/shadowsocks_config.js
@@ -368,8 +368,8 @@ exports.ONLINE_CONFIG_PROTOCOL = 'ssconf';
 // Parses access parameters to retrieve a Shadowsocks proxy config from an
 // online config URL. See: https://github.com/shadowsocks/shadowsocks-org/issues/89
 function parseOnlineConfigUrl(url) {
-  if (!url || !url.startsWith(exports.ONLINE_CONFIG_PROTOCOL)) {
-    throw new InvalidUri('URI must start with "' + exports.ONLINE_CONFIG_PROTOCOL + '"');
+  if (!url || !url.startsWith(exports.ONLINE_CONFIG_PROTOCOL + ':')) {
+    throw new InvalidUri('URI protocol must be "' + exports.ONLINE_CONFIG_PROTOCOL + '"');
   }
   // Replace the protocol "ssconf" with "https" to ensure correct results,
   // otherwise some Safari versions fail to parse it.
@@ -393,7 +393,7 @@ function parseOnlineConfigUrl(url) {
   var params = new url_1.URLSearchParams(tag.data);
   return {
     // Build the access URL with the parsed parameters Exclude the query string and tag.
-    url: 'https://' + uriFormattedHost + ':' + port.data + urlParserResult.pathname,
+    location: 'https://' + uriFormattedHost + ':' + port.data + urlParserResult.pathname,
     certFingerprint: params.get('certFp') || undefined,
     httpMethod: params.get('httpMethod') || undefined
   };

--- a/build/shadowsocks_config.js
+++ b/build/shadowsocks_config.js
@@ -389,7 +389,7 @@ function parseOnlineConfigUrl(url) {
   // The default URL parser fails to recognize the default HTTPs port (443).
   var port = new Port(urlParserResult.port || '443');
   // Parse extra parameters from the tag, which has the URL search parameters format.
-  var tag = new Tag(decodeURIComponent(urlParserResult.hash.substring(1)));
+  var tag = new Tag(urlParserResult.hash.substring(1));
   var params = new url_1.URLSearchParams(tag.data);
   return {
     // Build the access URL with the parsed parameters Exclude the query string and tag.

--- a/build/shadowsocks_config.js
+++ b/build/shadowsocks_config.js
@@ -26,6 +26,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var ipaddr = require("ipaddr.js");
 var js_base64_1 = require('js-base64');
 var punycode = require("punycode");
+var url_1 = require('url');
 // Custom error base class
 var ShadowsocksConfigError = /** @class */ (function (_super) {
     __extends(ShadowsocksConfigError, _super);
@@ -393,14 +394,14 @@ exports.SIP008_URI = {
         // Parse extra parameters from the tag, which has the format `#key0=val0;key1=val1...[;]`
         var extra = {};
         var tag = new Tag(decodeURIComponent(urlParserResult.hash.substring(1)));
-        for (var _i = 0, _a = tag.data.split(';'); _i < _a.length; _i++) {
-            var pair = _a[_i];
-            var _b = pair.split('=', 2), key = _b[0], value = _b[1];
-            if (!key) {
-                continue;
-            }
-            extra[key] = value;
-        }
+        // Convert tag to search parameters to leverage URLSearchParams parsing.
+        var params = new url_1.URLSearchParams(tag.data.replace(';', '&'));
+        params.forEach(function(value, key) {
+          if (!key) {
+            return;
+          }
+          extra[key] = value;
+        });
         var config = {
             // Build the access URL with the parsed parameters. Exclude the query string, as the spec
             // recommends against it.

--- a/src/shadowsocks_config.spec.ts
+++ b/src/shadowsocks_config.spec.ts
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  Host, Port, Method, Password, Tag, Config, makeConfig,
-  SHADOWSOCKS_URI, SIP002_URI, LEGACY_BASE64_URI, InvalidConfigField, InvalidUri,
-} from './shadowsocks_config';
+import {Config, Host, InvalidConfigField, InvalidUri, LEGACY_BASE64_URI, makeConfig, Method, Password, Port, SHADOWSOCKS_URI, SIP002_URI, SIP008_URI, Tag} from './shadowsocks_config';
 
 describe('shadowsocks_config', () => {
   describe('Config API', () => {
@@ -325,6 +322,50 @@ describe('shadowsocks_config', () => {
     it('throws when parsing invalid input', () => {
       expect(() => SHADOWSOCKS_URI.parse('not a URI')).toThrowError(InvalidUri);
       expect(() => SHADOWSOCKS_URI.parse('ss://not-base64')).toThrowError(InvalidUri);
+    });
+  });
+
+  describe('SIP008', () => {
+    it('can parse a valid ssconf URI with domain name and extras', () => {
+      const input = encodeURI(
+          'ssconf://my.domain.com/secret/long/path#certFp=AA:BB:CC:DD:EE:FF;sni=https://sni.other.com');
+      const dynamicConfig = SIP008_URI.parse(input);
+      expect(dynamicConfig.accessUrl).toEqual(new URL('https://my.domain.com/secret/long/path'));
+      expect(dynamicConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
+      expect(dynamicConfig.extra.sni).toEqual('https://sni.other.com');
+    });
+
+    it('can parse a valid ssconf URI with domain name and custom port', () => {
+      const input =
+          encodeURI('ssconf://my.domain.com:9090/secret/long/path#certFp=AA:BB:CC:DD:EE:FF;');
+      const dynamicConfig = SIP008_URI.parse(input);
+      expect(dynamicConfig.accessUrl)
+          .toEqual(new URL('https://my.domain.com:9090/secret/long/path'));
+      expect(dynamicConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
+    });
+
+    it('can parse a valid ssconf URI with hostname and no path', () => {
+      const input = encodeURI('ssconf://my.domain.com');
+      const dynamicConfig = SIP008_URI.parse(input);
+      expect(dynamicConfig.accessUrl).toEqual(new URL('https://my.domain.com'));
+      expect(dynamicConfig.extra.certFp).toBeUndefined();
+    });
+
+    it('can parse a valid ssconf URI with IPv4 address', () => {
+      const input =
+          encodeURI('ssconf://1.2.3.4/secret/long/path#certFp=AA:BB:CC:DD:EE:FF;other=param');
+      const dynamicConfig = SIP008_URI.parse(input);
+      expect(dynamicConfig.accessUrl).toEqual(new URL('https://1.2.3.4/secret/long/path'));
+      expect(dynamicConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
+    });
+
+    it('can parse a valid ssconf URI with IPv6 address and custom port', () => {
+      const input = encodeURI(
+          'ssconf://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path#certFp=AA:BB:CC:DD:EE:FF');
+      const dynamicConfig = SIP008_URI.parse(input);
+      expect(dynamicConfig.accessUrl)
+          .toEqual(new URL('https://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path'));
+      expect(dynamicConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
     });
   });
 });

--- a/src/shadowsocks_config.spec.ts
+++ b/src/shadowsocks_config.spec.ts
@@ -414,7 +414,8 @@ describe('shadowsocks_config', () => {
       const input = encodeURI(
           'ssconf://my.domain.com/secret/long/path#certFp=AA:BB:CC:DD:EE:FF&httpMethod=POST');
       const onlineConfig = parseOnlineConfigUrl(input);
-      expect(new URL(onlineConfig.url)).toEqual(new URL('https://my.domain.com/secret/long/path'));
+      expect(new URL(onlineConfig.location))
+          .toEqual(new URL('https://my.domain.com/secret/long/path'));
       expect(onlineConfig.certFingerprint).toEqual('AA:BB:CC:DD:EE:FF');
       expect(onlineConfig.httpMethod).toEqual('POST');
     });
@@ -423,7 +424,7 @@ describe('shadowsocks_config', () => {
       const input =
           encodeURI('ssconf://my.domain.com:9090/secret/long/path#certFp=AA:BB:CC:DD:EE:FF');
       const onlineConfig = parseOnlineConfigUrl(input);
-      expect(new URL(onlineConfig.url))
+      expect(new URL(onlineConfig.location))
           .toEqual(new URL('https://my.domain.com:9090/secret/long/path'));
       expect(onlineConfig.certFingerprint).toEqual('AA:BB:CC:DD:EE:FF');
     });
@@ -431,7 +432,7 @@ describe('shadowsocks_config', () => {
     it('can parse a valid ssconf URI with hostname and no path', () => {
       const input = encodeURI('ssconf://my.domain.com');
       const onlineConfig = parseOnlineConfigUrl(input);
-      expect(new URL(onlineConfig.url)).toEqual(new URL('https://my.domain.com'));
+      expect(new URL(onlineConfig.location)).toEqual(new URL('https://my.domain.com'));
       expect(onlineConfig.certFingerprint).toBeUndefined();
     });
 
@@ -439,7 +440,7 @@ describe('shadowsocks_config', () => {
       const input =
           encodeURI('ssconf://1.2.3.4/secret/long/path#certFp=AA:BB:CC:DD:EE:FF&other=param');
       const onlineConfig = parseOnlineConfigUrl(input);
-      expect(new URL(onlineConfig.url)).toEqual(new URL('https://1.2.3.4/secret/long/path'));
+      expect(new URL(onlineConfig.location)).toEqual(new URL('https://1.2.3.4/secret/long/path'));
       expect(onlineConfig.certFingerprint).toEqual('AA:BB:CC:DD:EE:FF');
     });
 
@@ -448,7 +449,7 @@ describe('shadowsocks_config', () => {
       const input = `ssconf://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path#certFp=${
           encodeURIComponent('AA:BB:CC:DD:EE:FF')}`;
       const onlineConfig = parseOnlineConfigUrl(input);
-      expect(new URL(onlineConfig.url))
+      expect(new URL(onlineConfig.location))
           .toEqual(new URL('https://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path'));
       expect(onlineConfig.certFingerprint).toEqual('AA:BB:CC:DD:EE:FF');
     });

--- a/src/shadowsocks_config.spec.ts
+++ b/src/shadowsocks_config.spec.ts
@@ -444,8 +444,9 @@ describe('shadowsocks_config', () => {
     });
 
     it('can parse a valid ssconf URI with IPv6 address and custom port', () => {
-      const input = encodeURI(
-          'ssconf://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path#certFp=AA:BB:CC:DD:EE:FF');
+      // encodeURI encodes the IPv6 address brackets.
+      const input = `ssconf://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path#certFp=${
+          encodeURIComponent('AA:BB:CC:DD:EE:FF')}`;
       const onlineConfig = SIP008_URI.parse(input);
       expect(new URL(onlineConfig.url))
           .toEqual(new URL('https://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path'));

--- a/src/shadowsocks_config.spec.ts
+++ b/src/shadowsocks_config.spec.ts
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Base64} from 'js-base64';
-
-import {Config, Host, InvalidConfigField, InvalidUri, LEGACY_BASE64_URI, makeConfig, Method, parseOnlineConfigUrl, Password, Port, SHADOWSOCKS_URI, SIP002_URI, Tag,} from './shadowsocks_config';
+import {Host, InvalidConfigField, InvalidUri, LEGACY_BASE64_URI, makeConfig, Method, parseOnlineConfigUrl, Password, Port, SHADOWSOCKS_URI, SIP002_URI, Tag,} from './shadowsocks_config';
 
 describe('shadowsocks_config', () => {
   describe('Config API', () => {
@@ -452,6 +450,15 @@ describe('shadowsocks_config', () => {
       expect(new URL(onlineConfig.location))
           .toEqual(new URL('https://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path'));
       expect(onlineConfig.certFingerprint).toEqual('AA:BB:CC:DD:EE:FF');
+    });
+
+    it('can parse a valid ssconf URI with URI-encoded tag', () => {
+      const certFp = '&=?:%';
+      const input = `ssconf://1.2.3.4/secret#certFp=${encodeURIComponent(certFp)}&httpMethod=GET`;
+      const onlineConfig = parseOnlineConfigUrl(input);
+      expect(new URL(onlineConfig.location)).toEqual(new URL('https://1.2.3.4/secret'));
+      expect(onlineConfig.certFingerprint).toEqual(certFp);
+      expect(onlineConfig.httpMethod).toEqual('GET');
     });
   });
 });

--- a/src/shadowsocks_config.spec.ts
+++ b/src/shadowsocks_config.spec.ts
@@ -14,7 +14,7 @@
 
 import {Base64} from 'js-base64';
 
-import {Config, Host, InvalidConfigField, InvalidUri, LEGACY_BASE64_URI, makeConfig, Method, Password, Port, SHADOWSOCKS_URI, SIP002_URI, SIP008_URI, Tag,} from './shadowsocks_config';
+import {Config, Host, InvalidConfigField, InvalidUri, LEGACY_BASE64_URI, makeConfig, Method, parseOnlineConfigUrl, Password, Port, SHADOWSOCKS_URI, SIP002_URI, Tag,} from './shadowsocks_config';
 
 describe('shadowsocks_config', () => {
   describe('Config API', () => {
@@ -412,45 +412,45 @@ describe('shadowsocks_config', () => {
   describe('SIP008', () => {
     it('can parse a valid ssconf URI with domain name and extras', () => {
       const input = encodeURI(
-          'ssconf://my.domain.com/secret/long/path#certFp=AA:BB:CC:DD:EE:FF;sni=https://sni.other.com');
-      const onlineConfig = SIP008_URI.parse(input);
+          'ssconf://my.domain.com/secret/long/path#certFp=AA:BB:CC:DD:EE:FF&httpMethod=POST');
+      const onlineConfig = parseOnlineConfigUrl(input);
       expect(new URL(onlineConfig.url)).toEqual(new URL('https://my.domain.com/secret/long/path'));
-      expect(onlineConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
-      expect(onlineConfig.extra.sni).toEqual('https://sni.other.com');
+      expect(onlineConfig.certFingerprint).toEqual('AA:BB:CC:DD:EE:FF');
+      expect(onlineConfig.httpMethod).toEqual('POST');
     });
 
     it('can parse a valid ssconf URI with domain name and custom port', () => {
       const input =
-          encodeURI('ssconf://my.domain.com:9090/secret/long/path#certFp=AA:BB:CC:DD:EE:FF;');
-      const onlineConfig = SIP008_URI.parse(input);
+          encodeURI('ssconf://my.domain.com:9090/secret/long/path#certFp=AA:BB:CC:DD:EE:FF');
+      const onlineConfig = parseOnlineConfigUrl(input);
       expect(new URL(onlineConfig.url))
           .toEqual(new URL('https://my.domain.com:9090/secret/long/path'));
-      expect(onlineConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
+      expect(onlineConfig.certFingerprint).toEqual('AA:BB:CC:DD:EE:FF');
     });
 
     it('can parse a valid ssconf URI with hostname and no path', () => {
       const input = encodeURI('ssconf://my.domain.com');
-      const onlineConfig = SIP008_URI.parse(input);
+      const onlineConfig = parseOnlineConfigUrl(input);
       expect(new URL(onlineConfig.url)).toEqual(new URL('https://my.domain.com'));
-      expect(onlineConfig.extra.certFp).toBeUndefined();
+      expect(onlineConfig.certFingerprint).toBeUndefined();
     });
 
     it('can parse a valid ssconf URI with IPv4 address', () => {
       const input =
-          encodeURI('ssconf://1.2.3.4/secret/long/path#certFp=AA:BB:CC:DD:EE:FF;other=param');
-      const onlineConfig = SIP008_URI.parse(input);
+          encodeURI('ssconf://1.2.3.4/secret/long/path#certFp=AA:BB:CC:DD:EE:FF&other=param');
+      const onlineConfig = parseOnlineConfigUrl(input);
       expect(new URL(onlineConfig.url)).toEqual(new URL('https://1.2.3.4/secret/long/path'));
-      expect(onlineConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
+      expect(onlineConfig.certFingerprint).toEqual('AA:BB:CC:DD:EE:FF');
     });
 
     it('can parse a valid ssconf URI with IPv6 address and custom port', () => {
       // encodeURI encodes the IPv6 address brackets.
       const input = `ssconf://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path#certFp=${
           encodeURIComponent('AA:BB:CC:DD:EE:FF')}`;
-      const onlineConfig = SIP008_URI.parse(input);
+      const onlineConfig = parseOnlineConfigUrl(input);
       expect(new URL(onlineConfig.url))
           .toEqual(new URL('https://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path'));
-      expect(onlineConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
+      expect(onlineConfig.certFingerprint).toEqual('AA:BB:CC:DD:EE:FF');
     });
   });
 });

--- a/src/shadowsocks_config.spec.ts
+++ b/src/shadowsocks_config.spec.ts
@@ -413,43 +413,43 @@ describe('shadowsocks_config', () => {
     it('can parse a valid ssconf URI with domain name and extras', () => {
       const input = encodeURI(
           'ssconf://my.domain.com/secret/long/path#certFp=AA:BB:CC:DD:EE:FF;sni=https://sni.other.com');
-      const dynamicConfig = SIP008_URI.parse(input);
-      expect(new URL(dynamicConfig.url)).toEqual(new URL('https://my.domain.com/secret/long/path'));
-      expect(dynamicConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
-      expect(dynamicConfig.extra.sni).toEqual('https://sni.other.com');
+      const onlineConfig = SIP008_URI.parse(input);
+      expect(new URL(onlineConfig.url)).toEqual(new URL('https://my.domain.com/secret/long/path'));
+      expect(onlineConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
+      expect(onlineConfig.extra.sni).toEqual('https://sni.other.com');
     });
 
     it('can parse a valid ssconf URI with domain name and custom port', () => {
       const input =
           encodeURI('ssconf://my.domain.com:9090/secret/long/path#certFp=AA:BB:CC:DD:EE:FF;');
-      const dynamicConfig = SIP008_URI.parse(input);
-      expect(new URL(dynamicConfig.url))
+      const onlineConfig = SIP008_URI.parse(input);
+      expect(new URL(onlineConfig.url))
           .toEqual(new URL('https://my.domain.com:9090/secret/long/path'));
-      expect(dynamicConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
+      expect(onlineConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
     });
 
     it('can parse a valid ssconf URI with hostname and no path', () => {
       const input = encodeURI('ssconf://my.domain.com');
-      const dynamicConfig = SIP008_URI.parse(input);
-      expect(new URL(dynamicConfig.url)).toEqual(new URL('https://my.domain.com'));
-      expect(dynamicConfig.extra.certFp).toBeUndefined();
+      const onlineConfig = SIP008_URI.parse(input);
+      expect(new URL(onlineConfig.url)).toEqual(new URL('https://my.domain.com'));
+      expect(onlineConfig.extra.certFp).toBeUndefined();
     });
 
     it('can parse a valid ssconf URI with IPv4 address', () => {
       const input =
           encodeURI('ssconf://1.2.3.4/secret/long/path#certFp=AA:BB:CC:DD:EE:FF;other=param');
-      const dynamicConfig = SIP008_URI.parse(input);
-      expect(new URL(dynamicConfig.url)).toEqual(new URL('https://1.2.3.4/secret/long/path'));
-      expect(dynamicConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
+      const onlineConfig = SIP008_URI.parse(input);
+      expect(new URL(onlineConfig.url)).toEqual(new URL('https://1.2.3.4/secret/long/path'));
+      expect(onlineConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
     });
 
     it('can parse a valid ssconf URI with IPv6 address and custom port', () => {
       const input = encodeURI(
           'ssconf://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path#certFp=AA:BB:CC:DD:EE:FF');
-      const dynamicConfig = SIP008_URI.parse(input);
-      expect(new URL(dynamicConfig.url))
+      const onlineConfig = SIP008_URI.parse(input);
+      expect(new URL(onlineConfig.url))
           .toEqual(new URL('https://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path'));
-      expect(dynamicConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
+      expect(onlineConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
     });
   });
 });

--- a/src/shadowsocks_config.spec.ts
+++ b/src/shadowsocks_config.spec.ts
@@ -330,7 +330,7 @@ describe('shadowsocks_config', () => {
       const input = encodeURI(
           'ssconf://my.domain.com/secret/long/path#certFp=AA:BB:CC:DD:EE:FF;sni=https://sni.other.com');
       const dynamicConfig = SIP008_URI.parse(input);
-      expect(dynamicConfig.accessUrl).toEqual(new URL('https://my.domain.com/secret/long/path'));
+      expect(new URL(dynamicConfig.url)).toEqual(new URL('https://my.domain.com/secret/long/path'));
       expect(dynamicConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
       expect(dynamicConfig.extra.sni).toEqual('https://sni.other.com');
     });
@@ -339,7 +339,7 @@ describe('shadowsocks_config', () => {
       const input =
           encodeURI('ssconf://my.domain.com:9090/secret/long/path#certFp=AA:BB:CC:DD:EE:FF;');
       const dynamicConfig = SIP008_URI.parse(input);
-      expect(dynamicConfig.accessUrl)
+      expect(new URL(dynamicConfig.url))
           .toEqual(new URL('https://my.domain.com:9090/secret/long/path'));
       expect(dynamicConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
     });
@@ -347,7 +347,7 @@ describe('shadowsocks_config', () => {
     it('can parse a valid ssconf URI with hostname and no path', () => {
       const input = encodeURI('ssconf://my.domain.com');
       const dynamicConfig = SIP008_URI.parse(input);
-      expect(dynamicConfig.accessUrl).toEqual(new URL('https://my.domain.com'));
+      expect(new URL(dynamicConfig.url)).toEqual(new URL('https://my.domain.com'));
       expect(dynamicConfig.extra.certFp).toBeUndefined();
     });
 
@@ -355,7 +355,7 @@ describe('shadowsocks_config', () => {
       const input =
           encodeURI('ssconf://1.2.3.4/secret/long/path#certFp=AA:BB:CC:DD:EE:FF;other=param');
       const dynamicConfig = SIP008_URI.parse(input);
-      expect(dynamicConfig.accessUrl).toEqual(new URL('https://1.2.3.4/secret/long/path'));
+      expect(new URL(dynamicConfig.url)).toEqual(new URL('https://1.2.3.4/secret/long/path'));
       expect(dynamicConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
     });
 
@@ -363,7 +363,7 @@ describe('shadowsocks_config', () => {
       const input = encodeURI(
           'ssconf://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path#certFp=AA:BB:CC:DD:EE:FF');
       const dynamicConfig = SIP008_URI.parse(input);
-      expect(dynamicConfig.accessUrl)
+      expect(new URL(dynamicConfig.url))
           .toEqual(new URL('https://[2001:0:ce49:7601:e866:efff:62c3:fffe]:8081/secret/long/path'));
       expect(dynamicConfig.extra.certFp).toEqual('AA:BB:CC:DD:EE:FF');
     });

--- a/src/shadowsocks_config.ts
+++ b/src/shadowsocks_config.ts
@@ -361,8 +361,7 @@ export const SIP008_URI = {
 
     // URL parser for expedience, replacing the protocol "ssconf" with "https" to ensure correct
     // results, otherwise browsers like Safari fail to parse it.
-    const inputForUrlParser =
-        `https${decodeURIComponent(uri.substring(SIP008_URI.PROTOCOL.length))}`;
+    const inputForUrlParser = uri.replace(new RegExp(`^${SIP008_URI.PROTOCOL}`), 'https');
     // The built-in URL parser throws as desired when given URIs with invalid syntax.
     const urlParserResult = new URL(inputForUrlParser);
     // Use ValidatedConfigFields subclasses (Host, Port, Tag) to throw on validation failure.

--- a/src/shadowsocks_config.ts
+++ b/src/shadowsocks_config.ts
@@ -333,7 +333,7 @@ export const SIP002_URI = {
 };
 
 export interface DynamicConfig {
-  accessUrl: URL;
+  url: string;
   // Any additional configuration (e.g. `timeout`, SIP003 `plugin`, etc.) may be stored here.
   extra: {[key: string]: string};
 }
@@ -384,7 +384,7 @@ export const SIP008_URI = {
     const config: DynamicConfig = {
       // Build the access URL with the parsed parameters. Exclude the query string, as the spec
       // recommends against it.
-      accessUrl: new URL(`https://${uriFormattedHost}:${port.data}${urlParserResult.pathname}`),
+      url: `https://${uriFormattedHost}:${port.data}${urlParserResult.pathname}`,
       extra
     };
     return config;

--- a/src/shadowsocks_config.ts
+++ b/src/shadowsocks_config.ts
@@ -15,6 +15,7 @@
 import * as ipaddr from 'ipaddr.js';
 import {Base64} from 'js-base64';
 import * as punycode from 'punycode';
+import {URLSearchParams} from 'url';
 
 // Custom error base class
 export class ShadowsocksConfigError extends Error {
@@ -380,13 +381,14 @@ export const SIP008_URI = {
     // Parse extra parameters from the tag, which has the format `#key0=val0;key1=val1...[;]`
     const extra = {} as {[key: string]: string};
     const tag = new Tag(decodeURIComponent(urlParserResult.hash.substring(1)));
-    for (const pair of tag.data.split(';')) {
-      const [key, value] = pair.split('=', 2);
+    // Convert tag to search parameters to leverage URLSearchParams parsing.
+    const params = new URLSearchParams(tag.data.replace(';', '&'));
+    params.forEach((value, key) => {
       if (!key) {
-        continue;
+        return;
       }
       extra[key] = value;
-    }
+    });
 
     const config: OnlineConfig = {
       // Build the access URL with the parsed parameters. Exclude the query string, as the spec

--- a/src/shadowsocks_config.ts
+++ b/src/shadowsocks_config.ts
@@ -375,7 +375,7 @@ export function parseOnlineConfigUrl(url: string): ConfigFetchParams {
   // The default URL parser fails to recognize the default HTTPs port (443).
   const port = new Port(urlParserResult.port || '443');
   // Parse extra parameters from the tag, which has the URL search parameters format.
-  const tag = new Tag(decodeURIComponent(urlParserResult.hash.substring(1)));
+  const tag = new Tag(urlParserResult.hash.substring(1));
   const params = new URLSearchParams(tag.data);
   return {
     // Build the access URL with the parsed parameters Exclude the query string and tag.

--- a/src/shadowsocks_config.ts
+++ b/src/shadowsocks_config.ts
@@ -339,10 +339,11 @@ export const SIP002_URI = {
   },
 };
 
-export interface DynamicConfig {
-  url: string;
-  // Any additional configuration (e.g. `timeout`, SIP003 `plugin`, etc.) may be stored here.
-  extra: {[key: string]: string};
+export interface OnlineConfig {
+  // URL endpoint to retrieve a Shadowsocks configuration.
+  readonly url: string;
+  // Any additional configuration (e.g. `certFp`, `httpMethod`, etc.) may be stored here.
+  readonly extra: {[key: string]: string};
 }
 
 // Ref: https://github.com/shadowsocks/shadowsocks-org/issues/89
@@ -355,7 +356,7 @@ export const SIP008_URI = {
     }
   },
 
-  parse: (uri: string): DynamicConfig => {
+  parse: (uri: string): OnlineConfig => {
     SIP008_URI.validateProtocol(uri);
 
     // URL parser for expedience, replacing the protocol "ssconf" with "https" to ensure correct
@@ -388,7 +389,7 @@ export const SIP008_URI = {
       extra[key] = value;
     }
 
-    const config: DynamicConfig = {
+    const config: OnlineConfig = {
       // Build the access URL with the parsed parameters. Exclude the query string, as the spec
       // recommends against it.
       url: `https://${uriFormattedHost}:${port.data}${urlParserResult.pathname}`,

--- a/src/shadowsocks_config.ts
+++ b/src/shadowsocks_config.ts
@@ -342,7 +342,7 @@ export const SIP002_URI = {
 
 export interface ConfigFetchParams {
   // URL endpoint to retrieve a Shadowsocks configuration.
-  readonly url: string;
+  readonly location: string;
   // Server cerficate hash.
   readonly certFingerprint?: string;
   // HTTP method to use when accessing `url`.
@@ -354,8 +354,8 @@ export const ONLINE_CONFIG_PROTOCOL = 'ssconf';
 // Parses access parameters to retrieve a Shadowsocks proxy config from an
 // online config URL. See: https://github.com/shadowsocks/shadowsocks-org/issues/89
 export function parseOnlineConfigUrl(url: string): ConfigFetchParams {
-  if (!url || !url.startsWith(ONLINE_CONFIG_PROTOCOL)) {
-    throw new InvalidUri(`URI must start with "${ONLINE_CONFIG_PROTOCOL}"`);
+  if (!url || !url.startsWith(`${ONLINE_CONFIG_PROTOCOL}:`)) {
+    throw new InvalidUri(`URI protocol must be "${ONLINE_CONFIG_PROTOCOL}"`);
   }
   // Replace the protocol "ssconf" with "https" to ensure correct results,
   // otherwise some Safari versions fail to parse it.
@@ -379,7 +379,7 @@ export function parseOnlineConfigUrl(url: string): ConfigFetchParams {
   const params = new URLSearchParams(tag.data);
   return {
     // Build the access URL with the parsed parameters Exclude the query string and tag.
-    url: `https://${uriFormattedHost}:${port.data}${urlParserResult.pathname}`,
+    location: `https://${uriFormattedHost}:${port.data}${urlParserResult.pathname}`,
     certFingerprint: params.get('certFp') || undefined,
     httpMethod: params.get('httpMethod') || undefined
   };


### PR DESCRIPTION
- Implements SIP008 URL encoding per the shadowsocks community [spec](https://github.com/shadowsocks/shadowsocks-org/wiki/SIP008-Online-Configuration-Delivery).
- Uses the `ssconf` URL protocol to support encoding parameters.
- Adds unit tests.