### PR TITLE
Prepare ssconf release

### DIFF
--- a/build/shadowsocks_config.js
+++ b/build/shadowsocks_config.js
@@ -26,7 +26,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var ipaddr = require("ipaddr.js");
 var js_base64_1 = require('js-base64');
 var punycode = require("punycode");
-var url_1 = require('url');
 // Custom error base class
 var ShadowsocksConfigError = /** @class */ (function (_super) {
     __extends(ShadowsocksConfigError, _super);
@@ -390,7 +389,7 @@ function parseOnlineConfigUrl(url) {
   var port = new Port(urlParserResult.port || '443');
   // Parse extra parameters from the tag, which has the URL search parameters format.
   var tag = new Tag(urlParserResult.hash.substring(1));
-  var params = new url_1.URLSearchParams(tag.data);
+  var params = new URLSearchParams(tag.data);
   return {
     // Build the access URL with the parsed parameters Exclude the query string and tag.
     location: 'https://' + uriFormattedHost + ':' + port.data + urlParserResult.pathname,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outline-shadowsocksconfig",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsc",

--- a/src/shadowsocks_config.ts
+++ b/src/shadowsocks_config.ts
@@ -15,7 +15,6 @@
 import * as ipaddr from 'ipaddr.js';
 import {Base64} from 'js-base64';
 import * as punycode from 'punycode';
-import {URLSearchParams} from 'url';
 
 // Custom error base class
 export class ShadowsocksConfigError extends Error {


### PR DESCRIPTION
- Removes an unecessary url import to fix a runtime failure on the browser/webview.
- Bumps the package minor version to release ssconf parsing.